### PR TITLE
Use Event.slug to form pyvo.cz URLs

### DIFF
--- a/pyvo-twitter.py
+++ b/pyvo-twitter.py
@@ -62,10 +62,8 @@ def get_events(date):
 def event_url(event):
     """
         Returns the URL for a Pyvo event.
-        
-        TODO: this should be provided by pyvo-db.
     """
-    return "https://pyvo.cz/{event.series.slug}/{event.year:04}-{event.month:02}/".format(event=event)
+    return "https://pyvo.cz/{event.series.slug}/{event.slug}/".format(event=event)
 
 @click.group()
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ GitPython==2.1.1
 Jinja2==2.9.4
 oauthlib==2.0.1
 python-dateutil==2.6.0
-pyvodb==0.3.3
+pyvodb==0.3.4
 PyYAML==3.12
 requests==2.12.4
 requests-oauthlib==0.7.0


### PR DESCRIPTION
Since 0.3.4 (commit [50ba96e](https://github.com/pyvec/pyvodb/commit/50ba96e5025a234fe72eac0d303f6522656168e3)), pyvodb Event objects have a dedicated property for forming URLs.
In the future, this can change to something more than `year-month`, so pyvo-twitter should use the slug.